### PR TITLE
CRUD Indicador + Ajustes CRUD Gestor

### DIFF
--- a/src/modules/gestor/dto/gestor.dto.ts
+++ b/src/modules/gestor/dto/gestor.dto.ts
@@ -1,0 +1,7 @@
+export class GestorDto {
+    nome: string;
+    imagem: string;
+    email: string;
+    area: string;
+    senha: string;
+}

--- a/src/modules/gestor/gestor.controller.ts
+++ b/src/modules/gestor/gestor.controller.ts
@@ -13,21 +13,21 @@ export class GestorController {
     }
 
     //pegar gestor
-    @Get(':nome')
-    async findOne(@Param('nome') nome: string) {
-      return this.gestorService.findOne(nome);
+    @Get(':email')
+    async findOne(@Param('email') email: string) {
+      return this.gestorService.findOne(email);
     }
 
     //excluir gestor
-    @Delete(':nome')
-    async remove(@Param('nome') nome: string) {
-      return this.gestorService.remove(nome);
+    @Delete(':email')
+    async remove(@Param('email') email: string) {
+      return this.gestorService.remove(email);
     }
 
     //pegar colaboradores do gestor
-    @Get('/colaboradores/:nome')
-    async findAllColFromOne(@Param('nome') nome: string) {
-      return this.gestorService.findAllColFromOne(nome);
+    @Get('/colaboradores/:email')
+    async findAllColFromOne(@Param('email') email: string) {
+      return this.gestorService.findAllColFromOne(email);
     }
 
 }

--- a/src/modules/gestor/gestor.controller.ts
+++ b/src/modules/gestor/gestor.controller.ts
@@ -1,5 +1,33 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import { GestorDto } from './dto/gestor.dto';
+import { GestorService } from './gestor.service';
 
-@Controller()
+@Controller('gestor')
 export class GestorController {
+    constructor(private readonly gestorService: GestorService) {}
+
+    //criar gestor
+    @Post()
+    async create(@Body() data: GestorDto){
+        return this.gestorService.create(data);
+    }
+
+    //pegar gestor
+    @Get(':nome')
+    async findOne(@Param('nome') nome: string) {
+      return this.gestorService.findOne(nome);
+    }
+
+    //excluir gestor
+    @Delete(':nome')
+    async remove(@Param('nome') nome: string) {
+      return this.gestorService.remove(nome);
+    }
+
+    //pegar colaboradores do gestor
+    @Get('/colaboradores/:nome')
+    async findAllColFromOne(@Param('nome') nome: string) {
+      return this.gestorService.findAllColFromOne(nome);
+    }
+
 }

--- a/src/modules/gestor/gestor.module.ts
+++ b/src/modules/gestor/gestor.module.ts
@@ -1,4 +1,10 @@
 import { Module } from '@nestjs/common';
+import { GestorController } from './gestor.controller';
+import { GestorService } from './gestor.service';
+import { PrismaService } from 'src/database/prisma.service';
 
-@Module({})
+@Module({
+    controllers: [GestorController],
+    providers: [GestorService, PrismaService],
+})
 export class GestorModule {}

--- a/src/modules/gestor/gestor.service.ts
+++ b/src/modules/gestor/gestor.service.ts
@@ -7,10 +7,10 @@ export class GestorService {
 
     constructor(private prisma: PrismaService) {}
 
-    existe (nome: string){
+    existe (email: string){
         return this.prisma.gestor.findFirst({
           where: {
-            nome: nome
+            email: email
           }
         })
       }
@@ -19,7 +19,7 @@ export class GestorService {
 
         //verificando se gestor já existe
        
-        const gestorExiste = await this.existe(data.nome);
+        const gestorExiste = await this.existe(data.email);
     
         if (gestorExiste) {
           throw new Error('Não é possível criar o mesmo gestor.')
@@ -34,8 +34,8 @@ export class GestorService {
         return gestor;
       }
 
-    async findOne(nome: string) {
-        const gestorExiste = await this.existe(nome);
+    async findOne(email: string) {
+        const gestorExiste = await this.existe(email);
     
         if (!gestorExiste) {
           throw new Error('Não é possível encontrar um gestor que NÃO EXISTE.')
@@ -44,8 +44,8 @@ export class GestorService {
         return gestorExiste;
       }
 
-    async remove(nome: string) {
-        const gestorExiste = await this.existe(nome);
+    async remove(email: string) {
+        const gestorExiste = await this.existe(email);
 
         if (!gestorExiste) {
           throw new Error('Não é possível remover um gestor que NÃO EXISTE.')
@@ -61,8 +61,8 @@ export class GestorService {
     
       }
       //dar mais atencao nos testes
-    async findAllColFromOne (nome: string){
-        const gestorExiste = await this.existe(nome);
+    async findAllColFromOne (email: string){
+        const gestorExiste = await this.existe(email);
 
         if (!gestorExiste) {
           throw new Error('Não é localizar colaboradores de um gestor que NÃO EXISTE.')

--- a/src/modules/gestor/gestor.service.ts
+++ b/src/modules/gestor/gestor.service.ts
@@ -1,4 +1,81 @@
 import { Injectable } from '@nestjs/common';
+import { GestorDto } from './dto/gestor.dto';
+import { PrismaService } from 'src/database/prisma.service';
 
 @Injectable()
-export class GestorService {}
+export class GestorService {
+
+    constructor(private prisma: PrismaService) {}
+
+    existe (nome: string){
+        return this.prisma.gestor.findFirst({
+          where: {
+            nome: nome
+          }
+        })
+      }
+
+    async create(data: GestorDto) {
+
+        //verificando se gestor já existe
+       
+        const gestorExiste = await this.existe(data.nome);
+    
+        if (gestorExiste) {
+          throw new Error('Não é possível criar o mesmo gestor.')
+        }
+        
+        
+    
+        const gestor = await this.prisma.gestor.create({
+          data
+        })
+    
+        return gestor;
+      }
+
+    async findOne(nome: string) {
+        const gestorExiste = await this.existe(nome);
+    
+        if (!gestorExiste) {
+          throw new Error('Não é possível encontrar um gestor que NÃO EXISTE.')
+        }
+    
+        return gestorExiste;
+      }
+
+    async remove(nome: string) {
+        const gestorExiste = await this.existe(nome);
+
+        if (!gestorExiste) {
+          throw new Error('Não é possível remover um gestor que NÃO EXISTE.')
+        }
+
+        const id = gestorExiste.id; 
+    
+        return await this.prisma.gestor.delete({
+          where: {
+            id,
+          }
+        })
+    
+      }
+      //dar mais atencao nos testes
+    async findAllColFromOne (nome: string){
+        const gestorExiste = await this.existe(nome);
+
+        if (!gestorExiste) {
+          throw new Error('Não é localizar colaboradores de um gestor que NÃO EXISTE.')
+        }
+
+        const id = gestorExiste.id;
+
+        return this.prisma.colaborador.findMany({
+            where: {
+                idGestor: id
+            }
+          })
+
+    }
+
+}

--- a/src/modules/indicador/dto/indicador.dto.ts
+++ b/src/modules/indicador/dto/indicador.dto.ts
@@ -1,0 +1,9 @@
+export class IndicadorDto {
+    nome: string;
+    unidade_medida: string; 
+    data_deadline: string;//DateTime
+    //exemplo de representacao na requisicao: "2020-03-09T22:18:26.625Z"
+    descricao: string;    
+    idGestor: string;
+    
+  }

--- a/src/modules/indicador/indicador.controller.ts
+++ b/src/modules/indicador/indicador.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
 import { IndicadorService } from './indicador.service';
 import { IndicadorDto } from './dto/indicador.dto';
 
@@ -28,6 +28,11 @@ export class IndicadorController {
     @Delete(':nomeInd')
     async remove(@Param('nomeInd') nomeInd: string) {
       return this.indicadorService.remove(nomeInd);
+    }
+
+    @Put(":nome")
+    async update(@Param("nome") nome:string, @Body() data:IndicadorDto) {
+      return this.indicadorService.update(nome, data);
     }
 
 }

--- a/src/modules/indicador/indicador.controller.ts
+++ b/src/modules/indicador/indicador.controller.ts
@@ -13,26 +13,26 @@ export class IndicadorController {
     }
 
     //pegar indicador      
-    @Get(':nomeInd')//atencao: pode haver mais de um indicador com msm nome e com dead line dif?
-    async findOne(@Param('nomeInd') nomeInd: string) {
-      return this.indicadorService.findOne(nomeInd);
+    @Get(':idGestor/:nomeInd')
+    async findOne(@Param('nomeInd') nomeInd: string,@Param('idGestor') idGestor: string) {
+      return this.indicadorService.findOne(nomeInd,idGestor);
     }
 
     //pegar todos indicadores de um gestor
-    @Get('/indicadoresDoGestor/:emailGest')
-    async findAllColFromOne(@Param('emailGest') emailGest: string) {
-      return this.indicadorService.findAllIndOfGest(emailGest);
+    @Get('/:idGestor')
+    async findAllColFromOne(@Param('idGestor') idGestor: string) {
+      return this.indicadorService.findAllIndOfGest(idGestor);
     }
 
     //excluir indicador
-    @Delete(':nomeInd')
-    async remove(@Param('nomeInd') nomeInd: string) {
-      return this.indicadorService.remove(nomeInd);
+    @Delete(':idGestor/:nomeInd')
+    async remove(@Param('nomeInd') nomeInd: string,@Param('idGestor') idGestor: string) {
+      return this.indicadorService.remove(nomeInd,idGestor);
     }
 
-    @Put(":nome")
-    async update(@Param("nome") nome:string, @Body() data:IndicadorDto) {
-      return this.indicadorService.update(nome, data);
+    @Put(":idGestor/:nomeInd")
+    async update(@Param('nomeInd') nomeInd: string,@Param('idGestor') idGestor: string, @Body() data:IndicadorDto) {
+      return this.indicadorService.update(nomeInd, idGestor, data);
     }
 
 }

--- a/src/modules/indicador/indicador.controller.ts
+++ b/src/modules/indicador/indicador.controller.ts
@@ -1,5 +1,33 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import { IndicadorService } from './indicador.service';
+import { IndicadorDto } from './dto/indicador.dto';
 
-@Controller()
+@Controller('indicador')
 export class IndicadorController {
+    constructor(private readonly indicadorService: IndicadorService) {}
+
+    //criar indicador para gestor
+    @Post()
+    async create(@Body() data: IndicadorDto){
+        return this.indicadorService.create(data);
+    }
+
+    //pegar indicador      
+    @Get(':nomeInd')//atencao: pode haver mais de um indicador com msm nome e com dead line dif?
+    async findOne(@Param('nomeInd') nomeInd: string) {
+      return this.indicadorService.findOne(nomeInd);
+    }
+
+    //pegar todos indicadores de um gestor
+    @Get('/indicadoresDoGestor/:emailGest')
+    async findAllColFromOne(@Param('emailGest') emailGest: string) {
+      return this.indicadorService.findAllIndOfGest(emailGest);
+    }
+
+    //excluir indicador
+    @Delete(':nomeInd')
+    async remove(@Param('nomeInd') nomeInd: string) {
+      return this.indicadorService.remove(nomeInd);
+    }
+
 }

--- a/src/modules/indicador/indicador.module.ts
+++ b/src/modules/indicador/indicador.module.ts
@@ -1,4 +1,10 @@
 import { Module } from '@nestjs/common';
+import { PrismaService } from 'src/database/prisma.service';
+import { IndicadorController } from './indicador.controller';
+import { IndicadorService } from './indicador.service';
 
-@Module({})
+@Module({
+    controllers: [IndicadorController],
+    providers: [IndicadorService, PrismaService],
+})
 export class IndicadorModule {}

--- a/src/modules/indicador/indicador.service.ts
+++ b/src/modules/indicador/indicador.service.ts
@@ -7,11 +7,12 @@ export class IndicadorService {
 
     constructor(private prisma: PrismaService) {}
 
-    existe (nomeInd: string){
-        //caso possa ter mais de um indicador -> fazer ajuste aqui
+    existe (nomeInd: string,idGestor: string){
+        
         return this.prisma.indicador.findFirst({
           where: {
-            nome: nomeInd
+            nome: nomeInd,
+            idGestor: idGestor
           }
         })
       }
@@ -20,7 +21,7 @@ export class IndicadorService {
 
         //verificando se indicador já existe
        
-        const indicadorExiste = await this.existe(data.nome);
+        const indicadorExiste = await this.existe(data.nome, data.idGestor);
     
         if (indicadorExiste) {
           throw new Error('Não é possível criar o mesmo indicador.')
@@ -35,8 +36,8 @@ export class IndicadorService {
         return indicador;
       }
 
-    async findOne(nomeInd: string) {
-        const indicadorExiste = await this.existe(nomeInd);
+    async findOne(nomeInd: string, idGestor: string) {
+        const indicadorExiste = await this.existe(nomeInd, idGestor);
     
         if (!indicadorExiste) {
           throw new Error('Não é possível encontrar um indicador que NÃO EXISTE.')
@@ -45,32 +46,17 @@ export class IndicadorService {
         return indicadorExiste;
       }
 
-    async findAllIndOfGest(emailGest: string){
-        //por estar utilizando o gestor, taalvez essa fosse uma func de gestor.service
-        //a menos que use o id de gestor ao inves do email
-        
-        //verificando se gestor existe
-        const gestorExiste = await this.prisma.gestor.findFirst({
-            where: {
-              email: emailGest
-            }
-        })
-
-        if (!gestorExiste) {
-            throw new Error('Não é possível localizar indicadores de um gestor que NÃO EXISTE.')
-        }
-
-        const id = gestorExiste.id;
+    async findAllIndOfGest(idGestor: string){
 
         return this.prisma.indicador.findMany({
               where: {
-                  idGestor: id
+                  idGestor: idGestor
               }
         })
     }
 
-    async remove(nome: string) {
-        const indicadorExiste = await this.existe(nome);
+    async remove(nomeInd: string, idGestor: string) {
+        const indicadorExiste = await this.existe(nomeInd, idGestor);
 
         if (!indicadorExiste) {
           throw new Error('Não é possível remover um indicador que NÃO EXISTE.')
@@ -86,8 +72,8 @@ export class IndicadorService {
     
     }
 
-    async update(nome: string, data: IndicadorDto) {
-      const indicadorExiste = await this.existe(data.nome);
+    async update(nomeInd: string, idGestor:string, data: IndicadorDto) {
+      const indicadorExiste = await this.existe(nomeInd,idGestor);
   
       if (!indicadorExiste) {
         throw new Error('Não é possível atualizar um indicador que NÃO EXISTE.')

--- a/src/modules/indicador/indicador.service.ts
+++ b/src/modules/indicador/indicador.service.ts
@@ -86,4 +86,23 @@ export class IndicadorService {
     
     }
 
+    async update(nome: string, data: IndicadorDto) {
+      const indicadorExiste = await this.existe(data.nome);
+  
+      if (!indicadorExiste) {
+        throw new Error('Não é possível atualizar um indicador que NÃO EXISTE.')
+      }
+      
+      const id = indicadorExiste.id;
+
+      return await this.prisma.indicador.update({
+        data,
+        where: { 
+          id,
+         },
+      })
+  
+      
+    }
+
 }

--- a/src/modules/indicador/indicador.service.ts
+++ b/src/modules/indicador/indicador.service.ts
@@ -1,4 +1,89 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/database/prisma.service';
+import { IndicadorDto } from './dto/indicador.dto';
 
 @Injectable()
-export class IndicadorService {}
+export class IndicadorService {
+
+    constructor(private prisma: PrismaService) {}
+
+    existe (nomeInd: string){
+        //caso possa ter mais de um indicador -> fazer ajuste aqui
+        return this.prisma.indicador.findFirst({
+          where: {
+            nome: nomeInd
+          }
+        })
+      }
+
+    async create(data: IndicadorDto) {
+
+        //verificando se indicador já existe
+       
+        const indicadorExiste = await this.existe(data.nome);
+    
+        if (indicadorExiste) {
+          throw new Error('Não é possível criar o mesmo indicador.')
+        }
+        
+        
+    
+        const indicador = await this.prisma.indicador.create({
+          data
+        })
+    
+        return indicador;
+      }
+
+    async findOne(nomeInd: string) {
+        const indicadorExiste = await this.existe(nomeInd);
+    
+        if (!indicadorExiste) {
+          throw new Error('Não é possível encontrar um indicador que NÃO EXISTE.')
+        }
+    
+        return indicadorExiste;
+      }
+
+    async findAllIndOfGest(emailGest: string){
+        //por estar utilizando o gestor, taalvez essa fosse uma func de gestor.service
+        //a menos que use o id de gestor ao inves do email
+        
+        //verificando se gestor existe
+        const gestorExiste = await this.prisma.gestor.findFirst({
+            where: {
+              email: emailGest
+            }
+        })
+
+        if (!gestorExiste) {
+            throw new Error('Não é possível localizar indicadores de um gestor que NÃO EXISTE.')
+        }
+
+        const id = gestorExiste.id;
+
+        return this.prisma.indicador.findMany({
+              where: {
+                  idGestor: id
+              }
+        })
+    }
+
+    async remove(nome: string) {
+        const indicadorExiste = await this.existe(nome);
+
+        if (!indicadorExiste) {
+          throw new Error('Não é possível remover um indicador que NÃO EXISTE.')
+        }
+
+        const id = indicadorExiste.id; 
+    
+        return await this.prisma.indicador.delete({
+          where: {
+            id,
+          }
+        })
+    
+    }
+
+}


### PR DESCRIPTION
**CRUD do indicador faz as ações 5 previstas:**
1. Criar indicador pro gestor
2. Buscar indicador específico*
3. Buscar todos os indicadores de um gestor**
4. Editar indicador*
5. Deletar indicador*
obs*: Como não há um atributo único, fiz essas ações baseadas no nome, mas acho válido fazer com id, só não sei se é funcional.
obs**: Vejo como uma possibilidade viável adicionar esta ação para o gestor, mas não acredito que seja necessária.

**Também foi realizada o ajuste no CRUD de Gestor, utilizando o email para fazer as devidas localizações dos GETs e do DELETE**