### PR TITLE
Controller de Colaborador Corrigido

### DIFF
--- a/src/modules/colaborador/colaborador.controller.ts
+++ b/src/modules/colaborador/colaborador.controller.ts
@@ -26,7 +26,7 @@ export class ColaboradorController {
 
     // pegar colaborador
     @Get(':id')
-    async findOne(@Body() id: string) {
+    async findOne(@Param('id') id: string) {
       return this.colaboradorService.findOne(id);
     }
 


### PR DESCRIPTION
Ao testar o GET (`findOne`) de Colaborador, durante a elaboração do **Documento de Templates para Requisições**, percebi que na URL era dado o ID do colaborador, mas se passava um id do `Body`. Apenas fiz uma modificação para que fosse utilizado o ID passado como parâmetro na URL.