### PR TITLE
Create Many de Colab.-Indi.

### DIFF
--- a/src/modules/colaborador-indicador/colaborador-indicador.controller.ts
+++ b/src/modules/colaborador-indicador/colaborador-indicador.controller.ts
@@ -12,7 +12,7 @@ import { CriarColaboradorIndicadorDto } from './dto/criar-colaborador-indicador.
 import { UpdateColaboradorIndicadorDto } from './dto/update-colaborador-indicador.dto';
 import { ColaboradorIndicadorService } from './colaborador-indicador.service';
 
-@Controller('colaborador-indicador')
+@Controller('colaborador-indicador/')
 export class ColaboradorIndicadorController {
   constructor(
     private readonly colaboradorIndicadorService: ColaboradorIndicadorService,
@@ -23,6 +23,13 @@ export class ColaboradorIndicadorController {
     return this.colaboradorIndicadorService.create(
       createColaboradorIndicadorDto,
     );
+  }
+
+  @Post('createMany/:dataDeadLine')
+  createMany(
+    @Param('dataDeadLine') dataDeadLine: string,
+    @Body() createColaboradorIndicadorDto: CriarColaboradorIndicadorDto) {
+    return this.colaboradorIndicadorService.createMany(createColaboradorIndicadorDto, dataDeadLine);
   }
 
   @Patch(':idColaboradorIndicador')

--- a/src/modules/colaborador-indicador/colaborador-indicador.service.ts
+++ b/src/modules/colaborador-indicador/colaborador-indicador.service.ts
@@ -110,30 +110,23 @@ export class ColaboradorIndicadorService {
     id: string,
     updateData: UpdateColaboradorIndicadorDto,
   ): Promise<ColaboradorIndicador> {
-    //verificar se sera necessario reenviar o valor de cada tipo de meta
-    //caso se ja - fazer um find com o id
 
-    return await this.prisma.colaboradorIndicador.update({
+    const colabInd = await this.prisma.colaboradorIndicador.update({
       where: { id },
       data: updateData,
     });
 
-    /*
-    const colabInd = await this.prisma.colaboradorIndicador.findFirst({
-      where: { id },
-    })
-
     var notaIndicador = 0;
 
-    if (colabInd.notaIndicador>=colabInd.desafio) {
+    if (colabInd.resultado>=colabInd.desafio) {
 
       notaIndicador=5;
 
-    } else if (colabInd.notaIndicador>=colabInd.superMeta) {
+    } else if (colabInd.resultado>=colabInd.superMeta) {
 
       notaIndicador=4;
 
-    } else if (colabInd.notaIndicador>=colabInd.meta) {
+    } else if (colabInd.resultado>=colabInd.meta) {
 
       notaIndicador= 3;
 
@@ -143,10 +136,10 @@ export class ColaboradorIndicadorService {
 
     }
 
-    await this.prisma.colaboradorIndicador.update({
+    return await this.prisma.colaboradorIndicador.update({
       where: { id },
-      {notaIndicador},
-    });*/
+      data :{notaIndicador},
+    });
 
 
   }

--- a/src/modules/colaborador-indicador/colaborador-indicador.service.ts
+++ b/src/modules/colaborador-indicador/colaborador-indicador.service.ts
@@ -110,10 +110,45 @@ export class ColaboradorIndicadorService {
     id: string,
     updateData: UpdateColaboradorIndicadorDto,
   ): Promise<ColaboradorIndicador> {
-    return this.prisma.colaboradorIndicador.update({
+    //verificar se sera necessario reenviar o valor de cada tipo de meta
+    //caso se ja - fazer um find com o id
+
+    return await this.prisma.colaboradorIndicador.update({
       where: { id },
       data: updateData,
     });
+
+    /*
+    const colabInd = await this.prisma.colaboradorIndicador.findFirst({
+      where: { id },
+    })
+
+    var notaIndicador = 0;
+
+    if (colabInd.notaIndicador>=colabInd.desafio) {
+
+      notaIndicador=5;
+
+    } else if (colabInd.notaIndicador>=colabInd.superMeta) {
+
+      notaIndicador=4;
+
+    } else if (colabInd.notaIndicador>=colabInd.meta) {
+
+      notaIndicador= 3;
+
+    }else{
+      //regra de 3 para calcular a nota
+      notaIndicador=(3 * colabInd.resultado)/colabInd.meta;
+
+    }
+
+    await this.prisma.colaboradorIndicador.update({
+      where: { id },
+      {notaIndicador},
+    });*/
+
+
   }
 
   async remove(id: string): Promise<ColaboradorIndicador> {

--- a/src/modules/indicador/indicador.service.ts
+++ b/src/modules/indicador/indicador.service.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/database/prisma.service';
 import { IndicadorDto } from './dto/indicador.dto';
-import { Indicador } from '@prisma/client';
 import { log } from 'console';
 
 @Injectable()
 export class IndicadorService {
 
     constructor(private prisma: PrismaService) {}
+    
 
     existe (nomeInd: string,idGestor: string){
         
@@ -19,48 +19,7 @@ export class IndicadorService {
         })
       }
 
-    mes_anoAtual () :string{
-      const dataAtual = new Date();
-      const anoAtual = dataAtual.getFullYear();
-      const mesAtual = dataAtual.getMonth()+1;
-      if (mesAtual < 10) {
-        return (anoAtual+'-0'+mesAtual+'-01T00:00:00.000Z');
-      }else{
-        return (anoAtual+'-'+mesAtual+'-01T00:00:00.000Z');
-      } 
-    }
 
-    listaMes_anoAteDeadLine (deadLine: string): string[] {
-      //tenho que colocar todos os mes_ano  ate a dead line em um array 
-      const mes_anoDeadLine = (deadLine.substring(0, 9))+'01T00:00:00.000Z';
-      var mes_ano = this.mes_anoAtual();
-      var chegouDead = false;
-      const meses_anos: string[] = []
-
-      while (!chegouDead){
-        if (mes_ano == mes_anoDeadLine) {
-          chegouDead=true;
-        }
-        meses_anos.push(mes_ano)
-        //prox mes e ano
-        var ano = parseInt(mes_ano.substring(0, 5));
-        var mes = parseInt(mes_ano.substring(5, 8));
-        if (mes==12) {
-          ano++;
-          mes=0;
-        }
-        mes++;
-        if (mes < 10) {
-          mes_ano = ano+'-0'+mes+'-01T00:00:00.000Z';
-        }else{
-          mes_ano = ano+'-'+mes+'-01T00:00:00.000Z';
-        }
-      }
-
-      return meses_anos;
-
-
-    }
 
     async create(data: IndicadorDto) {
 
@@ -76,9 +35,7 @@ export class IndicadorService {
     
         const indicador = await this.prisma.indicador.create({
           data
-        })
-        //Eh preciso criar um coborador-indicador para cada mes_ano ate a dead_line
-
+        })        
     
         return indicador;
       }

--- a/src/modules/metasMesIndicador/metas-mes-indicador.controller.ts
+++ b/src/modules/metasMesIndicador/metas-mes-indicador.controller.ts
@@ -30,6 +30,11 @@ export class MetasMesIndicadorController {
     async findAllByInterval(@Param('mes_ano') mes_ano: string, @Param('intervalo') intervalo: number) {
       return this.metasMesIndicadorService.findAllByInterval(mes_ano, intervalo);
     }
+
+    @Get('auxGraph/circularPB/FromHome/:mes_ano')
+    async getPercentualMetasBatidasByMonth(@Param('mes_ano') mes_ano: string) {
+      return this.metasMesIndicadorService.getPercentualMetasBatidasByMonth(mes_ano);
+    }
     
 
     //updade mmi

--- a/src/modules/metasMesIndicador/metas-mes-indicador.service.ts
+++ b/src/modules/metasMesIndicador/metas-mes-indicador.service.ts
@@ -59,6 +59,29 @@ export class MetasMesIndicadorService {
         return mmiExiste;
     }
 
+    async getPercentualMetasBatidasByMonth (mes_ano: string){
+
+      const mmis = await this.prisma.metasMesIndicador.findMany({
+        where: {
+          mes_ano: mes_ano
+        }
+      })
+
+      var numMetas = 0;
+      var metasBatidas = 0;
+
+      mmis.forEach(mmi => {
+        metasBatidas = metasBatidas + mmi.totalColabBateramMeta;
+        numMetas = numMetas + mmi.totalColab;
+      });
+
+      const result = metasBatidas/numMetas;
+
+      return result;
+
+
+  }
+
     async findAllMeses(idIndicador: string) {
       
       const mmi = await this.prisma.metasMesIndicador.findMany({


### PR DESCRIPTION
Esse método recebe um body normal de get, porém o campo **mes_ano** é desconsiderado:
{
	"mes_ano": "2023-06-01T00:00:00.000Z",	 // nao importa			
	"meta": 10,									
	"superMeta": 20,								
	"desafio": 30,								
	"peso": 2,								
	"resultado": 0,								
	"notaIndicador": 4,							
	"idColaborador": "12b7e207-3917-4f5a-95c9-c5f8318fe91a",	
	"idIndicador": "774624af-83eb-4799-b7df-8f0a7762a0c6"		
}


Utiliza o endereço **localhost:3000/colaborador-indicador/createMany/[dataDeadLine]**.

A funcionalidade deste método é a criação de todas as linhas de colab-indic necessárias, ele cria uma linha para cada mês entre o mês atual e a data de deadLine.

Também foi adicionado uma estrutura que não permite a criação de duas linhas com mesmo `mes_ano`, `idColaborador` e `idIndicador`